### PR TITLE
Refactor Pill component 

### DIFF
--- a/src/components/wrapper_components/Pill.WrapperComponent.tsx
+++ b/src/components/wrapper_components/Pill.WrapperComponent.tsx
@@ -2,18 +2,47 @@ import Chip from "@mui/material/Chip";
 
 interface PillProps {
   label: string;
-  color:
-    | "default"
-    | "primary"
-    | "secondary"
-    | "error"
-    | "info"
-    | "success"
-    | "warning";
+  color: string;
 }
 
+const VALID_PRE_DEFINED_COLORS = [
+  "default",
+  "primary",
+  "secondary",
+  "error",
+  "info",
+  "success",
+  "warning",
+];
+
+type PillColors =
+  | "default"
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning";
+
 const Pill: React.FC<PillProps> = (props) => {
-  return <Chip label={props.label} variant="outlined" color={props.color} />;
+  const IsHexColorCode = (colorCode: string): boolean => {
+    return !VALID_PRE_DEFINED_COLORS.includes(colorCode);
+  };
+
+  return (
+    <Chip
+      label={props.label}
+      variant="outlined"
+      color={
+        IsHexColorCode(props.color) ? "primary" : (props.color as PillColors)
+      }
+      sx={
+        IsHexColorCode(props.color)
+          ? { color: props.color, borderColor: props.color }
+          : null
+      }
+    />
+  );
 };
 
 export default Pill;


### PR DESCRIPTION
## Summary

Changed the `Pill component`, which accept the color as string for custom color.

## What are the changes?

- Changed the `color props` with, is accept string.
- Exposed `custom styling`, If the color is custom.

## PR Checklist

Please check your PR against the following requirements and update the check state accordingly.

- [ ] Does this PR includes any breaking changes.
- [X] Have you self-reviewed this PR on context with the previous PR changes.

closes #39