### PR TITLE
Expose Upload Files method to upload file on the server

### DIFF
--- a/src/models/request_response_models/FileUpload.response.ts
+++ b/src/models/request_response_models/FileUpload.response.ts
@@ -1,0 +1,6 @@
+interface FileUploadResponse {
+  filename: string;
+  url: string;
+}
+
+export default FileUploadResponse;

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -1,4 +1,5 @@
 import { RouteConfig } from "../configs/RouteConfig";
+import FileUploadResponse from "../models/request_response_models/FileUpload.response";
 import Topic from "../models/Topic.Model";
 import TopicDetail from "../models/TopicDetail.Model";
 import { HttpClient } from "./Client";
@@ -16,6 +17,23 @@ class ApiService {
       `${RouteConfig.topics}/${slug}`
     );
     return topic.data;
+  };
+
+  public static uploadFile = async (
+    file: File
+  ): Promise<FileUploadResponse> => {
+    let formData = new FormData();
+    formData.append("file", file);
+    let fileUpload = await HttpClient.post<FileUploadResponse, any>(
+      `${RouteConfig.files}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    return fileUpload.data;
   };
 }
 


### PR DESCRIPTION
# Summary
We need an API Service method to upload files on the server. So exposed the method and tested it worked.

# Changes
- Created a model for FileUploadResponse
- Exposed an API Service method to upload files on the server

Closes #102