### PR TITLE
Add additional links preview on Detail Screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cookbook",
       "version": "0.1.0",
       "dependencies": {
+        "@dhaiwat10/react-link-preview": "^1.14.1",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.4",
@@ -2112,6 +2113,18 @@
       "peerDependencies": {
         "postcss": "^8.3",
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dhaiwat10/react-link-preview": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@dhaiwat10/react-link-preview/-/react-link-preview-1.14.1.tgz",
+      "integrity": "sha512-ZEnCoAcSO5EhGYakylKQCoXJjkLLpjKz44A6QvrCzyPvtZQp4Wlf1vbJRaMH+1onFp48jSTMbr43FXsF6sc8vg==",
+      "dependencies": {
+        "react-loading-skeleton": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -14641,6 +14654,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-query": {
       "version": "3.39.1",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
@@ -18999,6 +19020,14 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
       "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
       "requires": {}
+    },
+    "@dhaiwat10/react-link-preview": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@dhaiwat10/react-link-preview/-/react-link-preview-1.14.1.tgz",
+      "integrity": "sha512-ZEnCoAcSO5EhGYakylKQCoXJjkLLpjKz44A6QvrCzyPvtZQp4Wlf1vbJRaMH+1onFp48jSTMbr43FXsF6sc8vg==",
+      "requires": {
+        "react-loading-skeleton": "^3.1.0"
+      }
     },
     "@emotion/babel-plugin": {
       "version": "11.9.2",
@@ -27901,6 +27930,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-loading-skeleton": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
+      "requires": {}
     },
     "react-query": {
       "version": "3.39.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@dhaiwat10/react-link-preview": "^1.14.1",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
@@ -15,8 +16,8 @@
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.6",
     "axios": "^0.27.2",
-    "notistack": "^2.0.5",
     "formik": "^2.2.9",
+    "notistack": "^2.0.5",
     "react": "^18.2.0",
     "react-code-blocks": "^0.0.9-0",
     "react-dom": "^18.2.0",

--- a/src/Pages/DetailsPage.page.tsx
+++ b/src/Pages/DetailsPage.page.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from "react";
 import { useQuery } from "react-query";
 
 import { useParams } from "react-router-dom";
+import CookbookContent from "../components/CookbookContent.component";
+import DetailScreenMainContent from "../components/DetailScreenMainContent";
 
-import MainContent from "../components/MainContent.component";
 import SideBar from "../components/SideBar.Component";
 import DrawerLayout from "../components/wrapper_components/DrawerLayout.WrapperComponent";
 import Header from "../components/wrapper_components/Header.Wrapper.component";
@@ -17,7 +18,7 @@ import ApiService from "../services/ApiService";
 const DetailsPage: React.FC = () => {
   const routeParams = useParams();
   const [stacks, setStacks] = useState<Stack[]>([]);
-  const [selectedStackName, setSelectedStackName] = useState<string>("");
+  const [selectedItemName, setSelectedItemName] = useState<string>("");
   const [selectedCookbook, setSelectedCookbook] = useState<Cookbook>();
 
   const { isLoading, data } = useQuery(
@@ -35,8 +36,8 @@ const DetailsPage: React.FC = () => {
   );
 
   useEffect(() => {
-    onStackSelected(selectedStackName);
-  }, [selectedStackName]);
+    onSidebarItemSelected(selectedItemName);
+  }, [selectedItemName]);
 
   const onSuccessfulTopicFetch = (response: TopicDetail) => {
     const extractedStacks: Stack[] = [];
@@ -46,7 +47,7 @@ const DetailsPage: React.FC = () => {
     setStacks(extractedStacks);
 
     if (extractedStacks.length > 0) {
-      setSelectedStackName(extractedStacks[0].name);
+      setSelectedItemName(extractedStacks[0].name);
     }
   };
 
@@ -64,10 +65,15 @@ const DetailsPage: React.FC = () => {
     }
   };
 
-  const onStackSelected = (stackName: string) => {
-    setSelectedStackName(stackName);
+  const onSidebarItemSelected = (selectedItem: string) => {
+    setSelectedItemName(selectedItem);
+
+    if (selectedItem === "additional_links") {
+      return;
+    }
+
     const cookbook = data?.cookbooks.find(
-      (cookbook) => cookbook.stack.name === stackName
+      (cookbook) => cookbook.stack.name === selectedItem
     );
     setSelectedCookbook(cookbook!);
   };
@@ -84,13 +90,20 @@ const DetailsPage: React.FC = () => {
         }
         leftNavigation={
           <SideBar
-            selectedStack={selectedStackName}
+            selectedStack={selectedItemName}
             stacks={stacks}
-            onSelect={onStackSelected}
+            onSelect={onSidebarItemSelected}
           />
         }
         mainContent={
-          <MainContent steps={selectedCookbook ? selectedCookbook.steps : []} />
+          <DetailScreenMainContent
+            steps={selectedCookbook ? selectedCookbook.steps : []}
+            additionalLinks={
+              selectedItemName === "additional_links"
+                ? data?.referenceUrls
+                : undefined
+            }
+          />
         }
       />
     </div>

--- a/src/components/AdditionalLinkItem.tsx
+++ b/src/components/AdditionalLinkItem.tsx
@@ -1,0 +1,16 @@
+import { LinkPreview } from "@dhaiwat10/react-link-preview";
+import React from "react";
+
+interface AdditionalLinkItemProps {
+  link: string;
+}
+
+const AdditionalLinkItem: React.FC<AdditionalLinkItemProps> = ({ link }) => {
+  return (
+    <div>
+      <LinkPreview url={link} height={350} />
+    </div>
+  );
+};
+
+export default AdditionalLinkItem;

--- a/src/components/AdditionalLinkList.tsx
+++ b/src/components/AdditionalLinkList.tsx
@@ -1,0 +1,25 @@
+import { Grid } from "@mui/material";
+import React from "react";
+import AdditionalLinkItem from "./AdditionalLinkItem";
+
+interface AdditionalLinkListProps {
+  links: string[];
+}
+
+const AdditionalLinkList: React.FC<AdditionalLinkListProps> = ({ links }) => {
+  return (
+    <React.Fragment>
+      <Grid container spacing={2}>
+        {links.map((link) => {
+          return (
+            <Grid item xs={12} sm={12} md={12} lg={4} key={link}>
+              <AdditionalLinkItem link={link} key={link} />
+            </Grid>
+          );
+        })}
+      </Grid>
+    </React.Fragment>
+  );
+};
+
+export default AdditionalLinkList;

--- a/src/components/AdditionalLinkMenuItem.tsx
+++ b/src/components/AdditionalLinkMenuItem.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import Color from "../configs/ColorConfig";
+
+interface AdditionalLinkMenuItemProps {
+  onSelect: Function;
+  icon: React.ReactNode;
+}
+
+const AdditionalLinkMenuItem: React.FC<AdditionalLinkMenuItemProps> = ({
+  onSelect,
+  icon,
+}) => {
+  return (
+    <ListItem key={"additional_links"} disablePadding>
+      <ListItemButton
+        sx={{
+          "&:hover": {
+            backgroundColor: Color.primaryLight,
+          },
+        }}
+        onClick={() => onSelect()}
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText
+          primary={"Additional Links"}
+          style={{ color: Color.textSecondaryColor }}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
+
+export default AdditionalLinkMenuItem;

--- a/src/components/CookbookContent.component.tsx
+++ b/src/components/CookbookContent.component.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import Step from "../models/Step.Model";
 import AccordionList from "./wrapper_components/AccordionList.WrapperComponent";
 
-interface MainContentProps {
+interface CookbookContentProps {
   steps: Step[];
 }
-const MainContent: React.FC<MainContentProps> = (props) => {
+const CookbookContent: React.FC<CookbookContentProps> = (props) => {
   return (
     <div>
       <AccordionList steps={props.steps} />
@@ -13,4 +13,4 @@ const MainContent: React.FC<MainContentProps> = (props) => {
   );
 };
 
-export default MainContent;
+export default CookbookContent;

--- a/src/components/DetailScreenMainContent.tsx
+++ b/src/components/DetailScreenMainContent.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Step from "../models/Step.Model";
+import AdditionalLinkList from "./AdditionalLinkList";
+import CookbookContent from "./CookbookContent.component";
+
+interface DetailScreenMainContentProps {
+  steps: Step[];
+  additionalLinks?: string[];
+}
+
+const DetailScreenMainContent: React.FC<DetailScreenMainContentProps> = ({
+  steps,
+  additionalLinks,
+}) => {
+  if (additionalLinks) {
+    return <AdditionalLinkList links={additionalLinks} />;
+  }
+
+  return <CookbookContent steps={steps} />;
+};
+
+export default DetailScreenMainContent;

--- a/src/components/SideBar.Component.tsx
+++ b/src/components/SideBar.Component.tsx
@@ -1,4 +1,5 @@
 import {
+  Divider,
   List,
   ListItem,
   ListItemButton,
@@ -10,6 +11,8 @@ import Icon from "./wrapper_components/Icon.WrapperComponent";
 
 import Color from "../configs/ColorConfig";
 import Stack from "../models/Stack.Model";
+import React from "react";
+import AdditionalLinkMenuItem from "./AdditionalLinkMenuItem";
 
 interface SideBarProps {
   selectedStack: string;
@@ -42,31 +45,51 @@ const SideBar: React.FC<SideBarProps> = ({
     if (stackName === "Xamarin Forms") {
       return <Icon type="xamarin" style={styles.logo} />;
     }
+
+    if (stackName === "links") {
+      return (
+        <Icon
+          type="links"
+          style={{ ...styles.logo, ...{ color: Color.primaryColor } }}
+        />
+      );
+    }
   };
 
   return (
-    <List>
-      {stacks.map((stack: Stack) => (
-        <ListItem key={stack._id} disablePadding>
-          <ListItemButton
-            sx={{
-              backgroundColor:
-                stack.name === selectedStack ? Color.primaryTintColor : null,
-              "&:hover": {
-                backgroundColor: Color.primaryLight,
-              },
-            }}
-            onClick={() => onSelect(stack.name)}
-          >
-            <ListItemIcon>{getIcon(stack.name)}</ListItemIcon>
-            <ListItemText
-              primary={stack.name}
-              style={{ color: Color.textSecondaryColor }}
-            />
-          </ListItemButton>
-        </ListItem>
-      ))}
-    </List>
+    <div>
+      <List>
+        {stacks.map((stack: Stack) => (
+          <ListItem key={stack._id} disablePadding>
+            <ListItemButton
+              sx={{
+                backgroundColor:
+                  stack.name === selectedStack ? Color.primaryTintColor : null,
+                "&:hover": {
+                  backgroundColor: Color.primaryLight,
+                },
+              }}
+              onClick={() => onSelect(stack.name)}
+            >
+              <ListItemIcon>{getIcon(stack.name)}</ListItemIcon>
+              <ListItemText
+                primary={stack.name}
+                style={{ color: Color.textSecondaryColor }}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <List>
+        <AdditionalLinkMenuItem
+          onSelect={() => {
+            onSelect("additional_links");
+          }}
+          icon={getIcon("links")}
+        />
+      </List>
+    </div>
   );
 };
 

--- a/src/components/wrapper_components/Icon.WrapperComponent.tsx
+++ b/src/components/wrapper_components/Icon.WrapperComponent.tsx
@@ -5,6 +5,7 @@ import Image from "@mui/icons-material/Image";
 import DeleteIcon from "@mui/icons-material/Delete";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import LinkIcon from "@mui/icons-material/Link";
 import { SvgIcon, SxProps, Theme } from "@mui/material";
 
 interface IconProps {
@@ -18,7 +19,8 @@ interface IconProps {
     | "swift"
     | "xamarin"
     | "moreVertIcon"
-    | "delete";
+    | "delete"
+    | "links";
   style?: SxProps<Theme>;
 }
 
@@ -148,6 +150,10 @@ const Icon: React.FC<IconProps> = (props) => {
 
   if (props.type === "delete") {
     return <DeleteIcon sx={props.style} />;
+  }
+
+  if (props.type === "links") {
+    return <LinkIcon sx={props.style} />;
   }
 
   return null;


### PR DESCRIPTION
# Summary
Additional Links was not displayed on Detail Screen previously. Now displayed it with link preview on Menu Item of Detail Screen.

# Changes
- Install `react-link-preview` package for link previews.
- Refactored Main Content to support Link Views and Cookbook Contents.
- Added `AdditionalLinkMenuItem`, `AdditionalLinkList`, `AdditionalLinkItem` components.
- Added `Link` icon to Icon Wrapper and Sidebar Icon List.

Closes #119