### PR TITLE
Resize image styles in AccordionContent component

### DIFF
--- a/src/components/wrapper_components/AccordionContent.Wrapper.tsx
+++ b/src/components/wrapper_components/AccordionContent.Wrapper.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import Text from "./Text.wrapperComponent";
 import CodeBlock from "./CodeBlock.WrapperComponent";
 import Linkify from "react-linkify";
+import { height, maxHeight } from "@mui/system";
 
 interface AccordianContentProps {
   content: string;
   code?: string;
   contentColor?: string;
   image?: string;
-  imageWidth?: string;
+  imageStyle?: React.CSSProperties;
 }
 
 const AccordionContent: React.FC<AccordianContentProps> = (props) => {
@@ -25,9 +26,11 @@ const AccordionContent: React.FC<AccordianContentProps> = (props) => {
       {props.image !== undefined && props.image!.trim() !== "" && (
         <div style={styles.imageContainer}>
           <img
-            style={{
-              width: props.imageWidth !== undefined ? props.imageWidth : "100%",
-            }}
+            style={
+              props.imageStyle !== undefined
+                ? props.imageStyle
+                : { height: "600px", width: "auto" }
+            }
             src={props.image}
             alt="could not found"
           />
@@ -47,6 +50,9 @@ const styles = {
   },
   imageContainer: {
     marginTop: "10px",
+    // display:'flex',
+    // justifyContent:'center',
+    // alignItems: 'center'
   },
 };
 

--- a/src/components/wrapper_components/AccordionContent.Wrapper.tsx
+++ b/src/components/wrapper_components/AccordionContent.Wrapper.tsx
@@ -50,9 +50,6 @@ const styles = {
   },
   imageContainer: {
     marginTop: "10px",
-    // display:'flex',
-    // justifyContent:'center',
-    // alignItems: 'center'
   },
 };
 


### PR DESCRIPTION
## Summary

Resize image styles in AccordionContent component

## What are the changes?
- Change image styles in AccordionComponent
- Change default height to 600px and width to auto
![resizeImage](https://user-images.githubusercontent.com/105632354/179801580-0ff8eeec-18e6-47da-9ed0-e4c0525655b3.png)

## PR Checklist

Please check your PR against the following requirements and update the check state accordingly.

- [ ] Does this PR includes any breaking changes.
- [X] Have you self-reviewed this PR on context with the previous PR changes.

closes #151

