### PR TITLE
Configure Update functionality in CreateTopic page

### DIFF
--- a/src/components/specified_components/actionable_components/ActionableMultiSelectChip.Component.tsx
+++ b/src/components/specified_components/actionable_components/ActionableMultiSelectChip.Component.tsx
@@ -13,6 +13,7 @@ interface ActionableMultiSelectChipProps {
   createNewTag: Function;
   title: string;
   errorMessage?: string;
+  defaultValues: string[];
 }
 
 const ActionableMultiSelectChip: React.FC<ActionableMultiSelectChipProps> = (
@@ -28,6 +29,7 @@ const ActionableMultiSelectChip: React.FC<ActionableMultiSelectChipProps> = (
           <MultipleSelectChip
             inputLabel="Tags"
             values={props.tags}
+            defaultValues={props.defaultValues}
             chipStyle={{ color: Theme.palette.primary.main }}
             menuItemStyle={{ color: Theme.palette.secondary.main }}
             onChange={(event) =>

--- a/src/components/wrapper_components/MultipleSelectChip.WrapperComponent.tsx
+++ b/src/components/wrapper_components/MultipleSelectChip.WrapperComponent.tsx
@@ -8,6 +8,7 @@ import MenuItem from "@mui/material/MenuItem";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { Theme, useTheme } from "@mui/material/styles";
+import { useEffect } from "react";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -59,6 +60,12 @@ const MultipleSelectChip: React.FC<MultipleSelectChipProps> = ({
   const [menuValues, setMenuValues] = React.useState<string[]>(
     defaultValues !== undefined ? defaultValues : []
   );
+
+  useEffect(() => {
+    if (defaultValues !== undefined) {
+      setMenuValues(defaultValues);
+    }
+  }, [defaultValues]);
 
   const handleChange = (
     event: SelectChangeEvent<typeof menuValues>,

--- a/src/configs/RouterConfig.tsx
+++ b/src/configs/RouterConfig.tsx
@@ -4,7 +4,7 @@ import CreateTag from "../pages/create_pages/CreateTag.page";
 import DetailsPage from "../pages/DetailsPage.page";
 import HomePage from "../pages/Home.page";
 import Stackpage from "../pages/create_pages/CreateStack.page";
-import TopicPage from "../pages/create_pages/CreateTopic.Page";
+import CreateTopic from "../pages/create_pages/CreateTopic.Page";
 import CreateAuthorPage from "../pages/create_pages/CreateAuthor.page";
 
 const RouterConfig = () => {
@@ -16,11 +16,12 @@ const RouterConfig = () => {
       <Route path="/create/stack" element={<Stackpage />} />
       <Route path="/create/cookbook" element={<CreateCookbookPage />} />
       <Route path="/create/tag" element={<CreateTag />} />
-      <Route path="/create/topic" element={<TopicPage />} />
+      <Route path="/create/topic" element={<CreateTopic />} />
       <Route path="/create/author" element={<CreateAuthorPage />} />
       <Route path="/edit/stack/:id" element={<Stackpage />} />
       <Route path="/edit/tag/:id" element={<CreateTag />} />
       <Route path="/edit/author/:id" element={<CreateAuthorPage />} />
+      <Route path="/edit/topic/:slug" element={<CreateTopic />} />
     </Routes>
   );
 };

--- a/src/models/request_response_models/TopicCreate.request.model.ts
+++ b/src/models/request_response_models/TopicCreate.request.model.ts
@@ -1,5 +1,5 @@
 interface TopicCreateRequest {
-  name: string;
+  title: string;
   flowchartUrl: string;
   tags?: string[];
   referenceUrls?: string[];

--- a/src/pages/create_pages/CreateTopic.Page.tsx
+++ b/src/pages/create_pages/CreateTopic.Page.tsx
@@ -299,7 +299,7 @@ const TopicPage = () => {
   return (
     <div style={styles.container}>
       <div style={{ ...styles.innerContainer }}>
-        <Title text="Create Topic" />
+        <Title text={slug ? "Update Topic" : "Create Topic"} />
       </div>
       <div
         style={{
@@ -426,7 +426,7 @@ const TopicPage = () => {
           style={{ ...styles.buttonsContainer, ...{ flexDirection: "column" } }}
         >
           <Clickable
-            ClickableText="Save"
+            ClickableText={slug ? "Update" : "Save"}
             onClick={onSave}
             variant={"contained"}
             clickableSize={"large"}

--- a/src/pages/create_pages/CreateTopic.Page.tsx
+++ b/src/pages/create_pages/CreateTopic.Page.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from "react";
 import { useMutation, useQuery } from "react-query";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { AxiosError } from "axios";
 import { v4 as uuid } from "uuid";
 
@@ -29,13 +29,19 @@ interface TopicErrors {
   fileUpload: boolean;
 }
 
+interface ReferenceURI {
+  id: string;
+  url: string;
+}
+
 const TopicPage = () => {
   const showErrorSnackBar = useErrorSnackbar();
   const navigate = useNavigate();
   const tabRouter = useTabRouter();
   const [showExitPrompt, setShowExitPrompt] = useExitPrompt(false);
+  const { slug } = useParams();
 
-  const [references, setReferences] = useState([
+  const [references, setReferences] = useState<ReferenceURI[]>([
     {
       id: uuid(),
       url: "",
@@ -48,7 +54,7 @@ const TopicPage = () => {
   });
 
   const emptyTopic: TopicCreateRequest = {
-    name: "",
+    title: "",
     flowchartUrl: "",
     tags: [],
     referenceUrls: [],
@@ -56,6 +62,42 @@ const TopicPage = () => {
   const [topic, setTopic] = useState<TopicCreateRequest>(emptyTopic);
 
   const tagsCall = useQuery("tags", () => ApiService.fetchTags());
+  const topicCall = useQuery(
+    ["topic", slug],
+    () => {
+      if (slug) {
+        return ApiService.fetchTopic(slug);
+      }
+    },
+    {
+      onSuccess: (data) => {
+        if (data) {
+          const clonedTopic = { ...topic };
+
+          clonedTopic.title = data.title;
+          clonedTopic.flowchartUrl = data.flowchartUrl;
+          clonedTopic.tags = data.tags.map((tags) => {
+            return tags.name;
+          });
+          clonedTopic.referenceUrls = data.referenceUrls;
+
+          const referenceUrlArray: ReferenceURI[] = data.referenceUrls.map(
+            (reference: string) => {
+              return {
+                id: uuid(),
+                url: reference,
+              };
+            }
+          );
+
+          setReferences(referenceUrlArray);
+
+          setTopic(clonedTopic);
+        }
+      },
+    }
+  );
+
   const topicCreateCall = useMutation(ApiService.addTopic, {
     onSuccess: () => {
       navigate("/create/cookbook");
@@ -64,6 +106,20 @@ const TopicPage = () => {
       showErrorSnackBar((error.response?.data as ErrorResponse).message);
     },
   });
+
+  const topicUpdateCall = useMutation(
+    (data: { id: string; editedtopic: TopicCreateRequest }) => {
+      return ApiService.updateTopic(data.id, data.editedtopic);
+    },
+    {
+      onSuccess: () => {
+        navigate("/topics");
+      },
+      onError: (error: AxiosError) => {
+        showErrorSnackBar((error.response?.data as ErrorResponse).message);
+      },
+    }
+  );
 
   useEffect(() => {
     const shouldShowExitPrompt = !isTopicEmpty();
@@ -78,7 +134,7 @@ const TopicPage = () => {
 
   const getTopic = (topicInput: string) => {
     const clonedTopic = { ...topic };
-    clonedTopic.name = topicInput;
+    clonedTopic.title = topicInput;
 
     setTopic(clonedTopic);
     validateName();
@@ -86,7 +142,7 @@ const TopicPage = () => {
 
   const onblurTopic = (topicInput: string) => {
     const clonedTopic = { ...topic };
-    clonedTopic.name = topicInput;
+    clonedTopic.title = topicInput;
 
     setTopic(clonedTopic);
     validateName();
@@ -99,10 +155,10 @@ const TopicPage = () => {
   const validateName = () => {
     const clonedErrors = { ...errors };
 
-    if (topic.name === "") {
+    if (topic.title === "") {
       clonedErrors.name = true;
     }
-    if (topic.name !== "") {
+    if (topic.title !== "") {
       clonedErrors.name = false;
     }
     setErrors(clonedErrors);
@@ -136,10 +192,10 @@ const TopicPage = () => {
   const validate = () => {
     const clonedErrors = { ...errors };
 
-    if (topic.name === "") {
+    if (topic.title === "") {
       clonedErrors.name = true;
     }
-    if (topic.name !== "") {
+    if (topic.title !== "") {
       clonedErrors.name = false;
     }
     if (topic.tags?.length === 0) {
@@ -169,10 +225,31 @@ const TopicPage = () => {
       return reference.url;
     });
     const clonedTopic = { ...topic };
+    const tagIds = topic.tags?.map((tagName) => {
+      const tag = tagsCall.data?.find((x) => x.name === tagName);
+      return tag!._id;
+    });
+    clonedTopic.tags = tagIds;
     clonedTopic.referenceUrls = referenceurl;
+
     if (!validate()) {
-      topicCreateCall.mutate(clonedTopic);
+      if (slug) {
+        updateTopic(topicCall.data?._id!, clonedTopic);
+        return;
+      }
+      createTopic(clonedTopic);
     }
+  };
+
+  const updateTopic = (id: string, clonedTopic: TopicCreateRequest) => {
+    topicUpdateCall.mutate({
+      id: topicCall.data?._id!,
+      editedtopic: clonedTopic,
+    });
+  };
+
+  const createTopic = (clonedTopic: TopicCreateRequest) => {
+    topicCreateCall.mutate(clonedTopic);
   };
 
   const createNewCookBook = () => {
@@ -198,16 +275,11 @@ const TopicPage = () => {
   };
 
   const onTagChange = (values: string[]) => {
-    const tagIds = values.map((tagName) => {
-      const tag = tagsCall.data?.find((x) => x.name === tagName);
-      return tag!._id;
-    });
-
     const clonedTopic = { ...topic };
-    clonedTopic.tags = tagIds;
+    clonedTopic.tags = values;
 
     setTopic(clonedTopic);
-    validateTags(tagIds);
+    validateTags(values);
   };
 
   const onTopicUpload = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -242,6 +314,7 @@ const TopicPage = () => {
             </Text>
             <div>
               <Input
+                value={topic.title}
                 onChange={(event) => {
                   getTopic(event.target.value);
                 }}
@@ -260,6 +333,7 @@ const TopicPage = () => {
               tags={
                 tagsCall.data ? tagsCall.data.map((tag: Tag) => tag.name) : []
               }
+              defaultValues={topic.tags ? topic.tags : []}
               createNewTag={() => navigate(`/create/tag`)}
               onTagChange={onTagChange}
               title="Tags"

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -117,7 +117,9 @@ class ApiService {
   };
 
   public static fetchCookBook = async (id: string): Promise<Cookbook> => {
-    let cookBook = await HttpClient.get<Cookbook>(`${RouteConfig.cookbooks}/${id}`);
+    let cookBook = await HttpClient.get<Cookbook>(
+      `${RouteConfig.cookbooks}/${id}`
+    );
     return cookBook.data;
   };
 
@@ -161,6 +163,17 @@ class ApiService {
       author
     );
     return updatedAuthor;
+  };
+  
+  public static updateTopic = async (
+    id: string,
+    topic: TopicCreateRequest
+  ): Promise<Topic> => {
+    let updatedtopic = await HttpClient.put<TopicCreateRequest, Topic>(
+      `${RouteConfig.topics}/${id}`,
+      topic
+    );
+    return updatedtopic;
   };
 }
 


### PR DESCRIPTION
## Summary

Configured edit functionality for a particular topic.

## What are the changes?
- Added a `route with slug` for to route Update Topic.
- Added a `updateTopic` method in `Apiservice.ts` file.
- Get the topic data and edit the topic even if the `queryparam` having slug. 

![update ned](https://user-images.githubusercontent.com/105510110/179997001-0ee6b43e-7875-4277-b329-bda0af5e1db9.png)


## PR Checklist

Please check your PR against the following requirements and update the check state accordingly.

- [ ] Does this PR includes any breaking changes.
- [X] Have you self-reviewed this PR on context with the previous PR changes.

closes #161