### PR TITLE
Reduce the number of line if the Topic name is too high

### DIFF
--- a/src/components/specified_components/topic_item_components/TopicItem.Component.tsx
+++ b/src/components/specified_components/topic_item_components/TopicItem.Component.tsx
@@ -47,9 +47,11 @@ const TopicItem: React.FC<TopicItemProps> = ({ topic, style, onSelect }) => {
           style={{ ...styles.innerContainer, ...{ flexDirection: "column" } }}
         >
           <div>
-            <Text variant="h4" color={Theme.palette.secondary.main}>
-              {topic.title}
-            </Text>
+            <div style={styles.titleContainer as React.CSSProperties}>
+              <Text variant="h4" color={Theme.palette.secondary.main}>
+                {topic.title}
+              </Text>
+            </div>
             <div className="tagsContainer">
               {topic.tags.map((item: Tag) => {
                 return (
@@ -94,6 +96,12 @@ const styles = {
     width: "24px",
     height: "24px",
     marginRight: "12px",
+  },
+  titleContainer: {
+    height: "auto",
+    maxHeight: "80px",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
   },
 };
 


### PR DESCRIPTION
## Summary

Reduce the number of line if the Topic name is too high in HomePage

## What are the changes?
- Implement  Styles for Title Text
- Implement overflow as `hidden` and textOverFlow as `ellipsis` 

![cord](https://user-images.githubusercontent.com/105632354/180013189-88f02084-2362-4f73-9e63-712657325045.png)


## PR Checklist

Please check your PR against the following requirements and update the check state accordingly.

- [ ] Does this PR includes any breaking changes.
- [X] Have you self-reviewed this PR on context with the previous PR changes.

closes #169

